### PR TITLE
config: add configurable pramble length parameter

### DIFF
--- a/grc/components/framers/satellites_ax100_framer.block.yml
+++ b/grc/components/framers/satellites_ax100_framer.block.yml
@@ -25,6 +25,10 @@ parameters:
     dtype: string
     default: '""'
     hide: part
+-   id: preamble_len
+    label: Preabmle length
+    dtype: int
+    default: 50
 
 inputs:
 -   domain: message
@@ -36,7 +40,7 @@ outputs:
 
 templates:
     imports: import satellites.components.framers
-    make: satellites.components.framers.ax100_framer(mode = ${mode}, scrambler = ${scrambler}, syncword = ${syncword}, options=${options})
+    make: satellites.components.framers.ax100_framer(mode = ${mode}, scrambler = ${scrambler}, syncword = ${syncword}, options=${options}, preamble_len = ${preamble_len})
 
 documentation: |-
     Deframes a signal using one of the two protocols of the GOMspace NanoCom AX100
@@ -51,6 +55,7 @@ documentation: |-
         Mode: indicates the AX100 mode (protocol), which can be ASM+Golay or Reed Solomon
         Scrambler: enables or disables the CCSDS synchronous scrambler (only ASM+Golay mode)
         Syncword: syncword to use
+        Preamble length: preamble length in bytes
         Command line options: options to pass down to the block, following the syntax of the gr_satellites command line tool
 
 file_format: 1

--- a/python/bindings/docstrings/pdu_insert_bytes_pydoc_template.h
+++ b/python/bindings/docstrings/pdu_insert_bytes_pydoc_template.h
@@ -7,7 +7,7 @@
  *
  */
 #include "pydoc_macros.h"
-#define D(...) DOC(gr,satellites, __VA_ARGS__ )
+#define D(...) DOC(gr, satellites, __VA_ARGS__)
 /*
   This file contains placeholders for docstrings for the Python bindings.
   Do not edit! These were automatically extracted during the binding process
@@ -15,13 +15,10 @@
  */
 
 
- 
- static const char *__doc_gr_satellites_pdu_insert_bytes = R"doc()doc";
+static const char* __doc_gr_satellites_pdu_insert_bytes = R"doc()doc";
 
 
- static const char *__doc_gr_satellites_pdu_insert_bytes_pdu_insert_bytes = R"doc()doc";
+static const char* __doc_gr_satellites_pdu_insert_bytes_pdu_insert_bytes = R"doc()doc";
 
 
- static const char *__doc_gr_satellites_pdu_insert_bytes_make = R"doc()doc";
-
-  
+static const char* __doc_gr_satellites_pdu_insert_bytes_make = R"doc()doc";

--- a/python/bindings/docstrings/u482c_encode_pydoc_template.h
+++ b/python/bindings/docstrings/u482c_encode_pydoc_template.h
@@ -7,7 +7,7 @@
  *
  */
 #include "pydoc_macros.h"
-#define D(...) DOC(gr,satellites, __VA_ARGS__ )
+#define D(...) DOC(gr, satellites, __VA_ARGS__)
 /*
   This file contains placeholders for docstrings for the Python bindings.
   Do not edit! These were automatically extracted during the binding process
@@ -15,13 +15,10 @@
  */
 
 
- 
- static const char *__doc_gr_satellites_u482c_encode = R"doc()doc";
+static const char* __doc_gr_satellites_u482c_encode = R"doc()doc";
 
 
- static const char *__doc_gr_satellites_u482c_encode_u482c_encode = R"doc()doc";
+static const char* __doc_gr_satellites_u482c_encode_u482c_encode = R"doc()doc";
 
 
- static const char *__doc_gr_satellites_u482c_encode_make = R"doc()doc";
-
-  
+static const char* __doc_gr_satellites_u482c_encode_make = R"doc()doc";

--- a/python/bindings/pdu_insert_bytes_python.cc
+++ b/python/bindings/pdu_insert_bytes_python.cc
@@ -30,32 +30,20 @@ namespace py = pybind11;
 void bind_pdu_insert_bytes(py::module& m)
 {
 
-    using pdu_insert_bytes    = ::gr::satellites::pdu_insert_bytes;
+    using pdu_insert_bytes = ::gr::satellites::pdu_insert_bytes;
 
 
-    py::class_<pdu_insert_bytes, gr::block, gr::basic_block,
-        std::shared_ptr<pdu_insert_bytes>>(m, "pdu_insert_bytes", D(pdu_insert_bytes))
+    py::class_<pdu_insert_bytes,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<pdu_insert_bytes>>(
+        m, "pdu_insert_bytes", D(pdu_insert_bytes))
 
         .def(py::init(&pdu_insert_bytes::make),
-           py::arg("pos"),
-           py::arg("bytes"),
-           D(pdu_insert_bytes,make)
-        )
-        
-
+             py::arg("pos"),
+             py::arg("bytes"),
+             D(pdu_insert_bytes, make))
 
 
         ;
-
-
-
-
 }
-
-
-
-
-
-
-
-

--- a/python/bindings/u482c_encode_python.cc
+++ b/python/bindings/u482c_encode_python.cc
@@ -30,34 +30,19 @@ namespace py = pybind11;
 void bind_u482c_encode(py::module& m)
 {
 
-    using u482c_encode    = ::gr::satellites::u482c_encode;
+    using u482c_encode = ::gr::satellites::u482c_encode;
 
 
-    py::class_<u482c_encode, gr::block, gr::basic_block,
-        std::shared_ptr<u482c_encode>>(m, "u482c_encode", D(u482c_encode))
+    py::class_<u482c_encode, gr::block, gr::basic_block, std::shared_ptr<u482c_encode>>(
+        m, "u482c_encode", D(u482c_encode))
 
         .def(py::init(&u482c_encode::make),
-           py::arg("verbose"),
-           py::arg("viterbi"),
-           py::arg("scrambler"),
-           py::arg("rs"),
-           D(u482c_encode,make)
-        )
-        
-
+             py::arg("verbose"),
+             py::arg("viterbi"),
+             py::arg("scrambler"),
+             py::arg("rs"),
+             D(u482c_encode, make))
 
 
         ;
-
-
-
-
 }
-
-
-
-
-
-
-
-

--- a/python/components/framers/ax100_framer.py
+++ b/python/components/framers/ax100_framer.py
@@ -34,9 +34,10 @@ class ax100_framer(gr.hier_block2, options_block):
         scrambler: scrambler to use, either 'CCSDS' or 'none'
                    (only for ASM mode) (str)
         syncword: syncword to use (str)
+        preamble_len: preamble length (int)
         options: Options from argparse
     """
-    def __init__(self, mode, scrambler='CCSDS', syncword=_syncword,
+    def __init__(self, mode, scrambler='CCSDS', syncword=_syncword, preamble_len=_preamble_len,
                  options=None):
         gr.hier_block2.__init__(
             self,
@@ -59,7 +60,7 @@ class ax100_framer(gr.hier_block2, options_block):
         self.fec = u482c_encode(
             self.options.verbose_fec, 0, 1 if scrambler == 'CCSDS' else 0, 1)
         self.insert_syncword = pdu_insert_bytes(0, syncword)
-        self.insert_preamble = pdu_insert_bytes(0, _preamble_len*_preamble)
+        self.insert_preamble = pdu_insert_bytes(0, preamble_len*_preamble)
         self.framer = pdu_to_tagged_stream(gr.types.byte_t, 'packet_len')
 
         self.msg_connect(

--- a/python/components/framers/ax100_framer.py
+++ b/python/components/framers/ax100_framer.py
@@ -37,8 +37,8 @@ class ax100_framer(gr.hier_block2, options_block):
         preamble_len: preamble length (int)
         options: Options from argparse
     """
-    def __init__(self, mode, scrambler='CCSDS', syncword=_syncword, preamble_len=_preamble_len,
-                 options=None):
+    def __init__(self, mode, scrambler='CCSDS', syncword=_syncword,
+                 preamble_len=_preamble_len, options=None):
         gr.hier_block2.__init__(
             self,
             'ax100_framer',


### PR DESCRIPTION
Add optional preamble length configuration. Default value kept for backward compatibility.